### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -21,7 +21,7 @@ setCalibrationRatio	KEYWORD2
 onLevelReached	KEYWORD2
 begin	KEYWORD2
 setLevel	KEYWORD2
-stop  KEYWORD2
+stop	KEYWORD2
 loop	KEYWORD2
 isIdle	KEYWORD2
 getCurrentLevel	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords