### PR TITLE
When level is unknown, don't go up but wait for a first setLevel command

### DIFF
--- a/src/Shutters/StoredState.cpp
+++ b/src/Shutters/StoredState.cpp
@@ -5,7 +5,7 @@ using namespace ShuttersInternal;
 StoredState::StoredState()
 : _upCourseTime(0)
 , _downCourseTime(0)
-, _level(0)
+, _level(LEVEL_NONE)
 {
 }
 
@@ -37,7 +37,7 @@ void StoredState::feed(const char* state) {
 bool StoredState::isValid() {
   bool upCourseTimeValid = _upCourseTime > 0;
   bool downCourseTimeValid = _downCourseTime > 0;
-  bool levelValid = _level <= 100;
+  bool levelValid = _level <= 100 || _level == LEVEL_NONE;
 
   return upCourseTimeValid && downCourseTimeValid && levelValid;
 }
@@ -92,5 +92,5 @@ const char* StoredState::getState() {
 void StoredState::reset() {
   _upCourseTime = 0;
   _downCourseTime = 0;
-  _level = 0;
+  _level = LEVEL_NONE;
 }


### PR DESCRIPTION
Allow LEVEL_NONE as valid in the StoredState.
At initialization, don't go up immediately, but wait for a setLevel
command that is 0 or 100 to start moving.
Only then, go to the STATE_RESETTING state.
When in STATE_RESETTING state, don't accept other setLevel or
stop commands until the move is finished, that is we are back in
STATE_IDLE with a known level.